### PR TITLE
Revert "bump version to 0.1.21 (#155)"

### DIFF
--- a/docs/_templates/github-pages-redirect.html
+++ b/docs/_templates/github-pages-redirect.html
@@ -3,8 +3,8 @@
   <head>
     <title>Redirecting to main branch docs</title>
     <meta charset="utf-8" />
-    <meta http-equiv="refresh" content="0; url=./v0.1.21/index.html" />
+    <meta http-equiv="refresh" content="0; url=./v0.1.18/index.html" />
     <meta http-equiv="Content-Security-Policy" content="default-src 'self', frame-ancestors 'none'">
-    <link rel="canonical" href="https://hirundo-io.github.io/hirundo/v0.1.21/index.html" />
+    <link rel="canonical" href="https://hirundo-io.github.io/hirundo/v0.1.18/index.html" />
   </head>
 </html>

--- a/hirundo/__init__.py
+++ b/hirundo/__init__.py
@@ -63,4 +63,4 @@ __all__ = [
     "load_from_zip",
 ]
 
-__version__ = "0.1.21"
+__version__ = "0.1.18"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ packages = ["hirundo"]
 
 [project]
 name = "hirundo"
-version = "0.1.21"
+version = "0.1.18"
 description = "This package is used to interface with Hirundo's platform. It provides a simple API to optimize your ML datasets."
 authors = [{ name = "Hirundo", email = "dev@hirundo.io" }]
 readme = "README.md"


### PR DESCRIPTION
This reverts commit 64c5d773383bf9d4c7a4fb36376dc4e2a0b06659.
The PR merged was missing the appropriate label :| so I want to revert and re-apply and merge again.